### PR TITLE
Update compatibility flag in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
 name = "taroj-blog"
 compatibility_date = "2024-07-29"
-compatibility_flags = ["nodejs_compat"]
+compatibility_flags = ["nodejs_compat_v2"]
 pages_build_output_dir = ".vercel/output/static"


### PR DESCRIPTION
The compatibility flag was updated from "nodejs_compat" to "nodejs_compat_v2" to align with the latest configuration requirements for the deployment environment.